### PR TITLE
Rely on Go Modules to ensure package dependencies and replicable builds. Testing go version 1.11 to 1.15

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,20 @@
+on: [push, pull_request]
+name: Test
+jobs:
+  test:
+    strategy:
+      matrix:
+        go-version: [1.11.x, 1.12.x, 1.13.x, 1.14.x, 1.15.x]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Check format
+      run: make checkfmt
+    - name: Test
+      run: make test

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,7 +14,5 @@ jobs:
         go-version: ${{ matrix.go-version }}
     - name: Checkout code
       uses: actions/checkout@v2
-    - name: Check format
-      run: make checkfmt
     - name: Test
       run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+.vscode/
+.idea/
+
+coverage.txt
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: go
-go:
-  - 1.5
-  - 1.6
-  - tip

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,38 @@
+# Go parameters
+GOCMD=GO111MODULE=on go
+GOBUILD=$(GOCMD) build
+GOINSTALL=$(GOCMD) install
+GOCLEAN=$(GOCMD) clean
+GOTEST=$(GOCMD) test
+GOGET=$(GOCMD) get
+GOMOD=$(GOCMD) mod
+GOFMT=$(GOCMD) fmt
+
+.PHONY: all test coverage
+all: test coverage
+
+checkfmt:
+	@echo 'Checking gofmt';\
+ 	bash -c "diff -u <(echo -n) <(gofmt -d .)";\
+	EXIT_CODE=$$?;\
+	if [ "$$EXIT_CODE"  -ne 0 ]; then \
+		echo '$@: Go files must be formatted with gofmt'; \
+	fi && \
+	exit $$EXIT_CODE
+
+lint:
+	$(GOGET) github.com/golangci/golangci-lint/cmd/golangci-lint
+	golangci-lint run
+
+get:
+	$(GOGET) -t -v ./...
+
+fmt:
+	$(GOFMT) ./...
+
+test: get fmt
+	$(GOTEST) -race -covermode=atomic ./...
+
+coverage: get test
+	$(GOTEST) -race -coverprofile=coverage.txt -covermode=atomic .
+

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/HdrHistogram/hdrhistogram-go

--- a/hdr_test.go
+++ b/hdr_test.go
@@ -1,11 +1,10 @@
 package hdrhistogram_test
 
 import (
+	hdrhistogram "github.com/HdrHistogram/hdrhistogram-go"
 	"math"
 	"reflect"
 	"testing"
-
-	"github.com/codahale/hdrhistogram"
 )
 
 func TestHighSigFig(t *testing.T) {

--- a/window_test.go
+++ b/window_test.go
@@ -1,9 +1,8 @@
 package hdrhistogram_test
 
 import (
+	hdrhistogram "github.com/HdrHistogram/hdrhistogram-go"
 	"testing"
-
-	"github.com/codahale/hdrhistogram"
 )
 
 func TestWindowedHistogram(t *testing.T) {


### PR DESCRIPTION
This is a small PR to push forward this project towards latest go version standards. 

- Rely on Go Modules to ensure package dependencies and replicable builds. We need this in order to: Automatically detect import statements and then update dependencies graph, lock, download, and install appropriate versions of packages.
[Quoting golang official docs](https://github.com/golang/go/wiki/Modules#go-modules):
     > In Go 1.14, module support is considered ready for production use, and all users are encouraged to migrate to modules from other dependency management systems.
- Rely on github actions to proceed with the tests ( removed travis depedency ). 
- Moved tests histogram reference to HdrHistogram/hdrhistogram-go. 
- Testing for go version 1.11 to 1.15, for both ubuntu, windows, and macos environments. 
