### PR TITLE
Fixed TestMean and TestStdDev to follow expected max value quantization error given sigfigs

### DIFF
--- a/hdr_test.go
+++ b/hdr_test.go
@@ -2,6 +2,7 @@ package hdrhistogram_test
 
 import (
 	hdrhistogram "github.com/HdrHistogram/hdrhistogram-go"
+	"github.com/stretchr/testify/assert"
 	"math"
 	"reflect"
 	"testing"
@@ -53,32 +54,29 @@ func TestValueAtQuantile(t *testing.T) {
 	}
 }
 
+
 func TestMean(t *testing.T) {
 	h := hdrhistogram.New(1, 10000000, 3)
-
 	for i := 0; i < 1000000; i++ {
 		if err := h.RecordValue(int64(i)); err != nil {
 			t.Fatal(err)
 		}
 	}
-
-	if v, want := h.Mean(), 500000.013312; v != want {
-		t.Errorf("Mean was %v, but expected %v", v, want)
-	}
+	assert.InDelta(t, 500000, h.Mean(), 500000*0.001)
 }
 
 func TestStdDev(t *testing.T) {
 	h := hdrhistogram.New(1, 10000000, 3)
-
+	total := 0.0
 	for i := 0; i < 1000000; i++ {
+		total += math.Pow(float64(i-500000.0), 2)
 		if err := h.RecordValue(int64(i)); err != nil {
 			t.Fatal(err)
 		}
 	}
-
-	if v, want := h.StdDev(), 288675.1403682715; v != want {
-		t.Errorf("StdDev was %v, but expected %v", v, want)
-	}
+	variance := total / float64(1000000-1)
+	stdDev := math.Sqrt(variance)
+	assert.InDelta(t, stdDev, h.StdDev(), stdDev*0.001)
 }
 
 func TestTotalCount(t *testing.T) {


### PR DESCRIPTION
This tests fixes two flaky tests and should allow us to be able to merge #21 without failing any test and with more confidence on the max quantization error check.