### PR TITLE
`ValueAtPercentile()` 4.5X on-cpu time optimization: remove expensive condition checks and re-use computation on hotpaths

### DIFF
--- a/hdr.go
+++ b/hdr.go
@@ -332,14 +332,29 @@ func (h *Histogram) ValueAtPercentile(percentile float64) int64 {
 	}
 
 	countAtPercentile := int64(((percentile / 100) * float64(h.totalCount)) + 0.5)
+	var countToIdx int64 = 0
+	var valueFromIdx int64 = 0
+	var subBucketIdx int32 = -1
+	var bucketIdx int32 = 0
 
-	i := h.iterator()
-	for i.nextCountAtIdx(countAtPercentile) {
+	for true {
+		if countToIdx >= countAtPercentile {
+			break
+		}
+		// increment bucket
+		subBucketIdx++
+		if subBucketIdx >= h.subBucketCount {
+			subBucketIdx = h.subBucketHalfCount
+			bucketIdx++
+		}
+
+		countToIdx += h.getCountAtIndex(bucketIdx, subBucketIdx)
+		valueFromIdx = h.valueFromIndex(bucketIdx, subBucketIdx)
 	}
 	if percentile == 0.0 {
-		return h.lowestEquivalentValue(i.valueFromIdx)
+		return h.lowestEquivalentValue(valueFromIdx)
 	}
-	return h.highestEquivalentValue(i.valueFromIdx)
+	return h.highestEquivalentValue(valueFromIdx)
 }
 
 // ValueAtPercentiles, given an slice of percentiles returns a map containing for each passed percentile,

--- a/hdr.go
+++ b/hdr.go
@@ -332,6 +332,14 @@ func (h *Histogram) ValueAtPercentile(percentile float64) int64 {
 	}
 
 	countAtPercentile := int64(((percentile / 100) * float64(h.totalCount)) + 0.5)
+	valueFromIdx := h.getValueFromIdxUpToCount(countAtPercentile)
+	if percentile == 0.0 {
+		return h.lowestEquivalentValue(valueFromIdx)
+	}
+	return h.highestEquivalentValue(valueFromIdx)
+}
+
+func (h *Histogram) getValueFromIdxUpToCount(countAtPercentile int64) int64 {
 	var countToIdx int64 = 0
 	var valueFromIdx int64 = 0
 	var subBucketIdx int32 = -1
@@ -353,10 +361,7 @@ func (h *Histogram) ValueAtPercentile(percentile float64) int64 {
 		countToIdx += h.getCountAtIndexGivenBucketBaseIdx(bucketBaseIdx, subBucketIdx)
 		valueFromIdx = int64(subBucketIdx) << uint(int64(bucketIdx)+h.unitMagnitude)
 	}
-	if percentile == 0.0 {
-		return h.lowestEquivalentValue(valueFromIdx)
-	}
-	return h.highestEquivalentValue(valueFromIdx)
+	return valueFromIdx
 }
 
 // ValueAtPercentiles, given an slice of percentiles returns a map containing for each passed percentile,

--- a/hdr.go
+++ b/hdr.go
@@ -346,7 +346,7 @@ func (h *Histogram) getValueFromIdxUpToCount(countAtPercentile int64) int64 {
 	var bucketIdx int32 = 0
 	bucketBaseIdx := h.getBucketBaseIdx(bucketIdx)
 
-	for true {
+	for {
 		if countToIdx >= countAtPercentile {
 			break
 		}
@@ -605,10 +605,6 @@ func (h *Histogram) countsIndex(bucketIdx, subBucketIdx int32) int32 {
 
 func (h *Histogram) getBucketBaseIdx(bucketIdx int32) int32 {
 	return (bucketIdx + 1) << uint(h.subBucketHalfCountMagnitude)
-}
-
-func (h *Histogram) countsIndexGivenBucketBaseIdx(bucketBaseIdx, subBucketIdx int32) int32 {
-	return bucketBaseIdx + subBucketIdx - h.subBucketHalfCount
 }
 
 // return the lowest (and therefore highest precision) bucket index that can represent the value

--- a/hdr.go
+++ b/hdr.go
@@ -331,21 +331,15 @@ func (h *Histogram) ValueAtPercentile(percentile float64) int64 {
 		percentile = 100
 	}
 
-	total := int64(0)
 	countAtPercentile := int64(((percentile / 100) * float64(h.totalCount)) + 0.5)
 
 	i := h.iterator()
-	for i.nextCountAtIdx() {
-		total += i.countAtIdx
-		if total >= countAtPercentile {
-			if percentile == 0.0 {
-				return h.lowestEquivalentValue(i.valueFromIdx)
-			}
-			return h.highestEquivalentValue(i.valueFromIdx)
-		}
+	for i.nextCountAtIdx(countAtPercentile) {
 	}
-
-	return 0
+	if percentile == 0.0 {
+		return h.lowestEquivalentValue(i.valueFromIdx)
+	}
+	return h.highestEquivalentValue(i.valueFromIdx)
 }
 
 // ValueAtPercentiles, given an slice of percentiles returns a map containing for each passed percentile,
@@ -372,7 +366,7 @@ func (h *Histogram) ValueAtPercentiles(percentiles []float64) (values map[float6
 	total := int64(0)
 	currentQuantileSlicePos := 0
 	i := h.iterator()
-	for currentQuantileSlicePos < totalQuantilesToCalculate && i.nextCountAtIdx() {
+	for currentQuantileSlicePos < totalQuantilesToCalculate && i.nextCountAtIdx(h.totalCount) {
 		total += i.countAtIdx
 		for currentQuantileSlicePos < totalQuantilesToCalculate && total >= countAtPercentiles[currentQuantileSlicePos] {
 			currentPercentile := percentiles[currentQuantileSlicePos]
@@ -622,8 +616,8 @@ type iterator struct {
 }
 
 // nextCountAtIdx does not update the iterator highestEquivalentValue in order to optimize cpu usage.
-func (i *iterator) nextCountAtIdx() bool {
-	if i.countToIdx >= i.h.totalCount {
+func (i *iterator) nextCountAtIdx(limit int64) bool {
+	if i.countToIdx >= limit {
 		return false
 	}
 	// increment bucket
@@ -645,7 +639,7 @@ func (i *iterator) nextCountAtIdx() bool {
 
 // Returns the next element in the iteration.
 func (i *iterator) next() bool {
-	if !i.nextCountAtIdx() {
+	if !i.nextCountAtIdx(i.h.totalCount) {
 		return false
 	}
 	i.highestEquivalentValue = i.h.highestEquivalentValue(i.valueFromIdx)

--- a/hdr.go
+++ b/hdr.go
@@ -340,10 +340,10 @@ func (h *Histogram) ValueAtPercentile(percentile float64) int64 {
 }
 
 func (h *Histogram) getValueFromIdxUpToCount(countAtPercentile int64) int64 {
-	var countToIdx int64 = 0
-	var valueFromIdx int64 = 0
+	var countToIdx int64
+	var valueFromIdx int64
 	var subBucketIdx int32 = -1
-	var bucketIdx int32 = 0
+	var bucketIdx int32
 	bucketBaseIdx := h.getBucketBaseIdx(bucketIdx)
 
 	for {

--- a/hdr_benchmark_test.go
+++ b/hdr_benchmark_test.go
@@ -40,14 +40,14 @@ func BenchmarkHistogramValueAtPercentile(b *testing.B) {
 	var sigfigs = 3
 	var totalDatapoints = 1000000
 	h, data := populateHistogramLogNormalDist(b, lowestDiscernibleValue, highestTrackableValue, sigfigs, totalDatapoints)
-	quantiles := make([]float64, b.N)
+	quantiles := make([]float64, totalDatapoints)
 	for i := range quantiles {
 		data[i] = rand.Float64() * 100.0
 	}
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		h.ValueAtPercentile(data[i])
+		h.ValueAtPercentile(data[i%totalDatapoints])
 	}
 }
 


### PR DESCRIPTION
## Summary of optimizations

Benchmark | Baseline ns/op | Comparison ns/op | % Improvement | Improvement factor
-- | -- | -- | -- | --
BenchmarkHistogramValueAtPercentile-8 | 31896 | 7569 | 76.27% | 4.2
BenchmarkHistogramValueAtPercentileGivenPercentileSlice-8 | 159894 | 33900 | 78.80% | 4.7

<img width="1037" alt="image" src="https://user-images.githubusercontent.com/5832149/130373030-542fa4fe-70f3-440a-8b7d-34deac7077bc.png">


## Detail of analysis/changes 
Looking at the baseline CPU time by function in the following manner:

```
go test -bench=BenchmarkHistogramValueAtPercentile -test.cpuprofile=BenchmarkHistogramValueAtPercentile-Baseline.txt -test.benchtime=10s
pprof -web BenchmarkHistogramValueAtPercentile-Baseline.txt
```

We can observe that the iterator `nextCountAtIdx()` is the responsible for the majority of the CPU time. ( Even after improving the percentile calculation on the latest release as showcased in #46 ).
<img width="678" alt="image" src="https://user-images.githubusercontent.com/5832149/130371965-32722cc7-28e9-45ef-ad4a-04b4f7395a50.png">

Doing the same analysis by line of code as follow:
```
go test -bench=BenchmarkHistogramValueAtPercentile -test.cpuprofile=BenchmarkHistogramValueAtPercentile-Baseline.txt -test.benchtime=10s
pprof -web -lines BenchmarkHistogramValueAtPercentile-Baseline.txt
```

We can observe that the top consuming LOC are:

<img width="876" alt="image" src="https://user-images.githubusercontent.com/5832149/130371999-90666285-cb77-4f09-b736-969ae19545a2.png">

- condition on [hdr.go#L626](https://github.com/HdrHistogram/hdrhistogram-go/blob/master/hdr.go#L626) taking ~11% of cpu-time: `if i.countToIdx >= i.h.totalCount` . Notice that we're doing a more restrictive check at [hdr.go#L340](https://github.com/HdrHistogram/hdrhistogram-go/blob/master/hdr.go#L340) `if total >= countAtPercentile {`, meaning we can completely avoid this condition check. 

- condition on [hdr.go#L631](https://github.com/HdrHistogram/hdrhistogram-go/blob/master/hdr.go#L631) taking ~11% of cpu-time: `if i.subBucketIdx >= i.h.subBucketCount {` 

- condition on [hdr.go#L636](https://github.com/HdrHistogram/hdrhistogram-go/blob/master/hdr.go#L636) taking ~7% of cpu-time: `if i.bucketIdx >= i.h.bucketCount {` . Given at max ( percentile 100 ) we will be at the limit of bucketCount we can completely avoid this duplicate check. 

- return of `getCountAtIdx` on [hdr.go#L643](https://github.com/HdrHistogram/hdrhistogram-go/blob/master/hdr.go#L643) taking ~19% of cpu-time: `return true` . Notice that the function is not inlined. We can move away from up to O(N+M) calls to `getCountAtIdx` to O(1) call of the new optimized method that we've introduced named `getValueFromIdxUpToCount`.

Looking further at hotspots we can also check that `getCountAtIndex` is also a good candidate for optimization (on [hdr.go#L640](https://github.com/HdrHistogram/hdrhistogram-go/blob/master/hdr.go#L640)  takes 13% CPU time). 

<img width="1112" alt="image" src="https://user-images.githubusercontent.com/5832149/130372391-8ba6f121-d996-46ec-b87f-e8affe6a41f5.png">

Even though we can't remove this call, we can reduce the amount of duplicate computation within it -- specifically on the inner calls to the calculation of `bucketBaseIdx` that don't change during the time we iterate on each bucket sub-buckets. With that in mind, we've introduced `getCountAtIndexGivenBucketBaseIdx`and only calculate the `bucketBaseIdx` on the iteration that change bucket ( meaning no wasted computation on sub-bucket flows ).

## Impact of the above optimizations
Following up on all the we've moved from a baseline of:
```
(base) fco@fcos-Air hdrhistogram-go % go test -bench=BenchmarkHistogramValueAtPercentile -test.benchtime=10s
goos: darwin
goarch: arm64
pkg: github.com/HdrHistogram/hdrhistogram-go
BenchmarkHistogramValueAtPercentile-8                             352322             31896 ns/op               0 B/op          0 allocs/op
BenchmarkHistogramValueAtPercentileGivenPercentileSlice-8          83769            159894 ns/op               0 B/op          0 allocs/op
BenchmarkHistogramValueAtPercentilesGivenPercentileSlice-8        244653             53997 ns/op             248 B/op          4 allocs/op
PASS
ok      github.com/HdrHistogram/hdrhistogram-go 40.829s
```

to the new optimized ValueAtPercentile / ValueAtPercentileGivenPercentileSlice:

```
(base) fco@fcos-Air hdrhistogram-go % go test -bench=BenchmarkHistogramValueAtPercentile  -test.benchtime=10s 
goos: darwin
goarch: arm64
pkg: github.com/HdrHistogram/hdrhistogram-go
BenchmarkHistogramValueAtPercentile-8                            1671085              7569 ns/op               0 B/op          0 allocs/op
BenchmarkHistogramValueAtPercentileGivenPercentileSlice-8         335668             33900 ns/op               0 B/op          0 allocs/op
BenchmarkHistogramValueAtPercentilesGivenPercentileSlice-8        229405             51147 ns/op             248 B/op          4 allocs/op
PASS
ok      github.com/HdrHistogram/hdrhistogram-go 45.063s
```


