### PR TITLE
[fix] Log writer: ensure histogram timestamps survive serialization roundtrip.

### DIFF
--- a/example_hdr_test.go
+++ b/example_hdr_test.go
@@ -2,8 +2,9 @@ package hdrhistogram_test
 
 import (
 	"fmt"
-	"github.com/HdrHistogram/hdrhistogram-go"
 	"os"
+
+	"github.com/HdrHistogram/hdrhistogram-go"
 )
 
 // This latency Histogram could be used to track and analyze the counts of
@@ -13,6 +14,7 @@ import (
 //   - 1 microsecond up to 10 milliseconds,
 //   - 100 microsecond (or better) from 10 milliseconds up to 10 seconds,
 //   - 300 microsecond (or better) from 10 seconds up to 30 seconds,
+//
 // nolint
 func ExampleNew() {
 	lH := hdrhistogram.New(1, 30000000, 4)
@@ -38,6 +40,7 @@ func ExampleNew() {
 //   - 1 microsecond up to 1 millisecond,
 //   - 1 millisecond (or better) up to one second,
 //   - 1 second (or better) up to it's maximum tracked value ( 30 seconds ).
+//
 // nolint
 func ExampleHistogram_RecordValue() {
 	lH := hdrhistogram.New(1, 30000000, 3)

--- a/log_writer.go
+++ b/log_writer.go
@@ -1,4 +1,4 @@
-//The log format encodes into a single file, multiple histograms with optional shared meta data.
+// The log format encodes into a single file, multiple histograms with optional shared meta data.
 package hdrhistogram
 
 import (
@@ -93,14 +93,14 @@ func (lw *HistogramLogWriter) OutputIntervalHistogramWithLogOptions(histogram *H
 		}
 		maxValueUnitRatio = logOptions.maxValueUnitRatio
 	}
-	startTime := usedStartTime - float64(lw.baseTime)/1000.0
-	endTime := usedEndTime - float64(lw.baseTime)/1000.0
+	startTime := (usedStartTime - float64(lw.baseTime)) / 1000.0
+	endTime := (usedEndTime - float64(lw.baseTime)) / 1000.0
 	maxValueAsDouble := float64(histogram.Max()) / maxValueUnitRatio
 	cpayload, err := histogram.Encode(V2CompressedEncodingCookieBase)
 	if err != nil {
 		return
 	}
-	_, err = lw.log.Write([]byte(fmt.Sprintf("%s%f,%f,%f,%s\n", tagStr, startTime, endTime, maxValueAsDouble, string(cpayload))))
+	_, err = lw.log.Write([]byte(fmt.Sprintf("%s%f,%f,%f,%s\n", tagStr, startTime, endTime-startTime, maxValueAsDouble, string(cpayload))))
 	return
 }
 

--- a/log_writer_test.go
+++ b/log_writer_test.go
@@ -2,9 +2,10 @@ package hdrhistogram
 
 import (
 	"bytes"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestHistogramLogWriter_empty(t *testing.T) {
@@ -45,6 +46,8 @@ func TestHistogramLogWriterReader(t *testing.T) {
 		err = histogram.RecordValue(int64(i))
 		assert.Nil(t, err)
 	}
+	histogram.SetStartTimeMs(1000)
+	histogram.SetEndTimeMs(2000)
 	err = writer.OutputIntervalHistogram(histogram)
 	assert.Equal(t, nil, err)
 	r := bytes.NewReader(b.Bytes())
@@ -54,6 +57,8 @@ func TestHistogramLogWriterReader(t *testing.T) {
 	assert.Equal(t, histogram.TotalCount(), outHistogram.TotalCount())
 	assert.Equal(t, histogram.LowestTrackableValue(), outHistogram.LowestTrackableValue())
 	assert.Equal(t, histogram.HighestTrackableValue(), outHistogram.HighestTrackableValue())
+	assert.Equal(t, histogram.StartTimeMs(), outHistogram.StartTimeMs())
+	assert.Equal(t, histogram.EndTimeMs(), outHistogram.EndTimeMs())
 }
 
 func TestHistogramLogReader_logV2(t *testing.T) {


### PR DESCRIPTION
Fixes two bugs in the histogram log writer's timestamp handling:

1. **Incorrect time unit**: Start time and interval were written in milliseconds instead of seconds
2. **Wrong field**: End time was written instead of interval duration

This PR adds test coverage to verify that `StartTimeMs` and `EndTimeMs` are correctly preserved during histogram serialization and deserialization.