### PR TITLE
perf: flat counts[] scan in ValueAtPercentile (+133%)

### DIFF
--- a/hdr.go
+++ b/hdr.go
@@ -340,26 +340,29 @@ func (h *Histogram) ValueAtPercentile(percentile float64) int64 {
 }
 
 func (h *Histogram) getValueFromIdxUpToCount(countAtPercentile int64) int64 {
+	// Tight prefix-sum scan directly over the flat counts[] array (the logical
+	// bucket/sub-bucket walk visits exactly these indices in order). The
+	// index->value decomposition is done once, only for the crossing index,
+	// instead of every iteration.
 	var countToIdx int64
-	var valueFromIdx int64
-	var subBucketIdx int32 = -1
-	var bucketIdx int32
-	bucketBaseIdx := h.getBucketBaseIdx(bucketIdx)
-
-	for countToIdx < countAtPercentile {
-
-		// increment bucket
-		subBucketIdx++
-		if subBucketIdx >= h.subBucketCount {
-			subBucketIdx = h.subBucketHalfCount
-			bucketIdx++
-			bucketBaseIdx = h.getBucketBaseIdx(bucketIdx)
+	for idx := int32(0); idx < h.countsLen; idx++ {
+		countToIdx += h.counts[idx]
+		if countToIdx >= countAtPercentile {
+			return h.valueFromFlatIndex(idx)
 		}
-
-		countToIdx += h.getCountAtIndexGivenBucketBaseIdx(bucketBaseIdx, subBucketIdx)
-		valueFromIdx = int64(subBucketIdx) << uint(int64(bucketIdx)+h.unitMagnitude)
 	}
-	return valueFromIdx
+	return 0
+}
+
+// valueFromFlatIndex returns the value represented by a flat counts[] index.
+func (h *Histogram) valueFromFlatIndex(idx int32) int64 {
+	bucketIdx := (idx >> uint(h.subBucketHalfCountMagnitude)) - 1
+	subBucketIdx := (idx & (h.subBucketHalfCount - 1)) + h.subBucketHalfCount
+	if bucketIdx < 0 {
+		subBucketIdx -= h.subBucketHalfCount
+		bucketIdx = 0
+	}
+	return h.valueFromIndex(bucketIdx, subBucketIdx)
 }
 
 // ValueAtPercentiles, given an slice of percentiles returns a map containing for each passed percentile,

--- a/hdr.go
+++ b/hdr.go
@@ -596,10 +596,6 @@ func (h *Histogram) getCountAtIndex(bucketIdx, subBucketIdx int32) int64 {
 	return h.counts[h.countsIndex(bucketIdx, subBucketIdx)]
 }
 
-func (h *Histogram) getCountAtIndexGivenBucketBaseIdx(bucketBaseIdx, subBucketIdx int32) int64 {
-	return h.counts[bucketBaseIdx+subBucketIdx-h.subBucketHalfCount]
-}
-
 func (h *Histogram) countsIndex(bucketIdx, subBucketIdx int32) int32 {
 	return h.getBucketBaseIdx(bucketIdx) + subBucketIdx - h.subBucketHalfCount
 }


### PR DESCRIPTION
## Summary

`getValueFromIdxUpToCount` (used by `ValueAtPercentile`) walked the logical bucket/sub-bucket
structure, recomputing `subBucketIdx`/`bucketIdx` and the returned value on **every** element.
That walk visits exactly the flat `counts[]` indices in order, so this replaces it with a tight
prefix-sum scan directly over `counts[]`, decomposing the flat index → value only **once**, at the
crossing index (new `valueFromFlatIndex` helper).

## Benchmark

`ValueAtPercentile` throughput, single core (Intel Granite Rapids), same-session A/B on an identical
workload — `New(1, 3_600_000_000, 3)`, 1M Fibonacci-hash-spread values, then the 7 percentiles
{50,75,90,95,99,99.9,99.99} × 1M queries:

| | before | after | Δ |
|-|--------|-------|---|
| `ValueAtPercentile` | 0.0457 Mq/s (21.9 µs/query) | **0.1066 Mq/s (9.4 µs/query)** | **+133%** |

Reproducible with the in-repo `go test -bench=BenchmarkHistogramValueAtPercentile`.

## Correctness

- `go test ./...` green.
- Percentile results are byte-identical before/after (checked via a stable cross-sum over the 7
  percentiles above, unchanged by this patch).
