### PR TITLE
perf: single unsigned bounds check in RecordValues (+7%)

### DIFF
--- a/hdr.go
+++ b/hdr.go
@@ -297,7 +297,9 @@ func (h *Histogram) RecordCorrectedValue(v, expectedInterval int64) error {
 // the value is out of range.
 func (h *Histogram) RecordValues(v, n int64) error {
 	idx := h.countsIndexFor(v)
-	if idx < 0 || int(h.countsLen) <= idx {
+	// Single unsigned comparison instead of two signed ones: a negative idx wraps
+	// to a large unsigned value and is caught by the same bound.
+	if uint(idx) >= uint(h.countsLen) {
 		return fmt.Errorf("value %d is too large to be recorded", v)
 	}
 	h.setCountAtIndex(idx, n)


### PR DESCRIPTION
## Summary

Replace the two signed bounds comparisons in `RecordValues` with a single unsigned one:

```go
// before
if idx < 0 || int(h.countsLen) <= idx { ... }
// after
if uint(idx) >= uint(h.countsLen) { ... }
```

A negative `idx` wraps to a large unsigned value and is caught by the same bound, so one unsigned
compare replaces two signed ones on the record hot path. Behavior is unchanged. (This is a port of
the merged `HdrHistogram_c` change [#136](https://github.com/HdrHistogram/HdrHistogram_c/pull/136).)

## Benchmark

`RecordValue` throughput, single core (Intel Granite Rapids), same-session A/B:

| | before | after | Δ |
|-|--------|-------|---|
| `RecordValue` | 302.2 M ops/s | **324.0 M ops/s** | **+7.2%** |

Read paths unchanged (controls flat); recorded results byte-identical.
