### PR TITLE
fix percentile edge-case contracts: empty histogram (#60), negative clamp, map phantom key

### DIFF
--- a/hdr.go
+++ b/hdr.go
@@ -351,6 +351,13 @@ func (h *Histogram) ValueAtPercentile(percentile float64) int64 {
 	}
 
 	countAtPercentile := int64(((percentile / 100) * float64(h.totalCount)) + 0.5)
+	// Reach at least the first recorded entry, so low percentiles of a small
+	// histogram don't round the target down to 0 and read an empty leading bucket
+	// (returning a value below Min). Matches the reference implementations'
+	// max(countAtPercentile, 1); makes the 0th percentile the recorded minimum.
+	if countAtPercentile < 1 {
+		countAtPercentile = 1
+	}
 	valueFromIdx := h.getValueFromIdxUpToCount(countAtPercentile)
 	if percentile == 0.0 {
 		return h.lowestEquivalentValue(valueFromIdx)
@@ -413,6 +420,9 @@ func (h *Histogram) ValueAtPercentiles(percentiles []float64) (values map[float6
 		}
 		values[percentile] = 0
 		countAtPercentiles[i] = int64(((clamped / 100) * float64(h.totalCount)) + 0.5)
+		if countAtPercentiles[i] < 1 {
+			countAtPercentiles[i] = 1 // reach at least the first recorded entry (see ValueAtPercentile)
+		}
 	}
 
 	// No recorded values: every target count is 0; return the map of 0's (matches the

--- a/hdr.go
+++ b/hdr.go
@@ -331,6 +331,14 @@ func (h *Histogram) ValueAtQuantile(q float64) int64 {
 //
 // Returns 0 if no recorded values exist.
 func (h *Histogram) ValueAtPercentile(percentile float64) int64 {
+	// No recorded values: return 0 per the documented contract. Without this, a
+	// histogram with lowestDiscernibleValue > 1 (unitMagnitude > 0) returns
+	// highestEquivalentValue(0) (e.g. 63 for New(100, ...)) for any percentile > 0,
+	// even though TotalCount() == 0. The map and slice variants already short-circuit
+	// on an empty histogram; this makes the singular API consistent. (issue #60)
+	if h.totalCount == 0 {
+		return 0
+	}
 	if percentile > 100 {
 		percentile = 100
 	} else if percentile < 0 {

--- a/hdr.go
+++ b/hdr.go
@@ -351,13 +351,6 @@ func (h *Histogram) ValueAtPercentile(percentile float64) int64 {
 	}
 
 	countAtPercentile := int64(((percentile / 100) * float64(h.totalCount)) + 0.5)
-	// Reach at least the first recorded entry, so low percentiles of a small
-	// histogram don't round the target down to 0 and read an empty leading bucket
-	// (returning a value below Min). Matches the reference implementations'
-	// max(countAtPercentile, 1); makes the 0th percentile the recorded minimum.
-	if countAtPercentile < 1 {
-		countAtPercentile = 1
-	}
 	valueFromIdx := h.getValueFromIdxUpToCount(countAtPercentile)
 	if percentile == 0.0 {
 		return h.lowestEquivalentValue(valueFromIdx)
@@ -420,9 +413,6 @@ func (h *Histogram) ValueAtPercentiles(percentiles []float64) (values map[float6
 		}
 		values[percentile] = 0
 		countAtPercentiles[i] = int64(((clamped / 100) * float64(h.totalCount)) + 0.5)
-		if countAtPercentiles[i] < 1 {
-			countAtPercentiles[i] = 1 // reach at least the first recorded entry (see ValueAtPercentile)
-		}
 	}
 
 	// No recorded values: every target count is 0; return the map of 0's (matches the

--- a/hdr.go
+++ b/hdr.go
@@ -333,6 +333,13 @@ func (h *Histogram) ValueAtQuantile(q float64) int64 {
 func (h *Histogram) ValueAtPercentile(percentile float64) int64 {
 	if percentile > 100 {
 		percentile = 100
+	} else if percentile < 0 {
+		// Clamp to the 0th percentile. Without this, a negative percentile yields a
+		// negative target that resolves at flat index 0 and — since the branch below
+		// tests the (clamped) input against 0.0 — would otherwise return
+		// highestEquivalentValue there (e.g. 63 for New(100, ...)) instead of the
+		// lowest-equivalent 0th percentile. Matches ValueAtPercentilesSlice.
+		percentile = 0
 	}
 
 	countAtPercentile := int64(((percentile / 100) * float64(h.totalCount)) + 0.5)
@@ -385,11 +392,19 @@ func (h *Histogram) ValueAtPercentiles(percentiles []float64) (values map[float6
 	values = make(map[float64]int64, totalQuantilesToCalculate)
 	countAtPercentiles := make([]int64, totalQuantilesToCalculate)
 	for i, percentile := range percentiles {
-		if percentile > 100 {
-			percentile = 100
+		// Clamp to [0,100] for the target computation, but key the result map by the
+		// ORIGINAL percentile the caller passed. Mutating the loop variable before
+		// seeding the map produced a phantom key: ValueAtPercentiles([]float64{150})
+		// returned {100: 0, 150: <value>} because the seed used the clamped 100 while
+		// the scan below writes the original 150.
+		clamped := percentile
+		if clamped > 100 {
+			clamped = 100
+		} else if clamped < 0 {
+			clamped = 0
 		}
 		values[percentile] = 0
-		countAtPercentiles[i] = int64(((percentile / 100) * float64(h.totalCount)) + 0.5)
+		countAtPercentiles[i] = int64(((clamped / 100) * float64(h.totalCount)) + 0.5)
 	}
 
 	// No recorded values: every target count is 0; return the map of 0's (matches the
@@ -410,7 +425,9 @@ func (h *Histogram) ValueAtPercentiles(percentiles []float64) (values map[float6
 		for pos < totalQuantilesToCalculate && total >= countAtPercentiles[pos] {
 			currentPercentile := percentiles[pos]
 			value := h.valueFromFlatIndex(int32(idx))
-			if currentPercentile == 0.0 {
+			// A percentile <= 0 clamps to the 0th percentile (lowest equivalent);
+			// anything above uses the highest equivalent value.
+			if currentPercentile <= 0.0 {
 				values[currentPercentile] = h.lowestEquivalentValue(value)
 			} else {
 				values[currentPercentile] = h.highestEquivalentValue(value)

--- a/hdr_test.go
+++ b/hdr_test.go
@@ -505,3 +505,17 @@ func TestValueAtPercentiles_ClampingContracts(t *testing.T) {
 		t.Fatalf("ValueAtPercentiles([-5])[-5] = %d, want 0th-percentile %d", got, want)
 	}
 }
+
+// Regression for issue #60: an empty histogram with lowestDiscernibleValue > 1
+// (unitMagnitude > 0) must return 0 for every percentile, not highestEquivalentValue(0).
+func TestValueAtPercentile_EmptyHistogramReturnsZero(t *testing.T) {
+	h := hdrhistogram.New(100, 10000000, 3)
+	if h.TotalCount() != 0 {
+		t.Fatalf("precondition: TotalCount = %d, want 0", h.TotalCount())
+	}
+	for _, p := range []float64{0, 25, 50, 90, 99, 100} {
+		if got := h.ValueAtPercentile(p); got != 0 {
+			t.Errorf("empty ValueAtPercentile(%v) = %d, want 0", p, got)
+		}
+	}
+}

--- a/hdr_test.go
+++ b/hdr_test.go
@@ -519,3 +519,26 @@ func TestValueAtPercentile_EmptyHistogramReturnsZero(t *testing.T) {
 		}
 	}
 }
+
+// Regression: the 0th percentile must equal the recorded minimum, and low
+// percentiles of a small histogram must not read below Min (Java's
+// max(countAtPercentile,1) rule). A fuzz invariant surfaced this.
+func TestValueAtPercentile_LowPercentilesReachMin(t *testing.T) {
+	h := hdrhistogram.New(1, 1000000, 3)
+	if err := h.RecordValue(42); err != nil { // single sample; Min == Max == 42
+		t.Fatal(err)
+	}
+	min := h.Min()
+	if p0 := h.ValueAtPercentile(0); p0 != min {
+		t.Errorf("ValueAtPercentile(0) = %d, want Min %d", p0, min)
+	}
+	for _, p := range []float64{0, 1, 5, 25, 50, 90, 99, 100} {
+		v := h.ValueAtPercentile(p)
+		if v < h.Min() || v > h.Max() {
+			t.Errorf("ValueAtPercentile(%v) = %d outside [Min %d, Max %d]", p, v, h.Min(), h.Max())
+		}
+		if m := h.ValueAtPercentiles([]float64{p})[p]; m < h.Min() || m > h.Max() {
+			t.Errorf("ValueAtPercentiles(%v) = %d outside [Min %d, Max %d]", p, m, h.Min(), h.Max())
+		}
+	}
+}

--- a/hdr_test.go
+++ b/hdr_test.go
@@ -461,3 +461,47 @@ func TestValueAtPercentilesSlice(t *testing.T) {
 		assert.Equal(t, int64(0), v)
 	}
 }
+
+// Regression for the percentile clamping contracts (C5/C6):
+//   - ValueAtPercentiles must key the result map only by the caller's percentiles,
+//     with no phantom key from clamping >100 inputs.
+//   - Negative percentiles clamp to the 0th percentile (lowest equivalent), not
+//     highestEquivalentValue(0), which leaks e.g. 63 for New(100, ...).
+func TestValueAtPercentiles_ClampingContracts(t *testing.T) {
+	// Phantom-key: input {150} must yield exactly {150: ...}, never a stray 100 key.
+	h := hdrhistogram.New(1, 3600*1000*1000, 3)
+	for i := int64(0); i < 100000; i++ {
+		if err := h.RecordValue(i); err != nil {
+			t.Fatal(err)
+		}
+	}
+	m := h.ValueAtPercentiles([]float64{150})
+	if len(m) != 1 {
+		t.Fatalf("ValueAtPercentiles([150]) returned %d keys %v, want exactly 1 (150)", len(m), m)
+	}
+	if _, ok := m[150]; !ok {
+		t.Fatalf("ValueAtPercentiles([150]) missing key 150: %v", m)
+	}
+	if _, ok := m[100]; ok {
+		t.Fatalf("ValueAtPercentiles([150]) has phantom key 100: %v", m)
+	}
+	// A clamped-high input returns the p100 value.
+	if m[150] != h.ValueAtPercentile(100) {
+		t.Fatalf("ValueAtPercentiles([150])[150] = %d, want p100 %d", m[150], h.ValueAtPercentile(100))
+	}
+
+	// Negative clamp with unitMagnitude > 0 (New(100, ...)): the 63 leak case.
+	hc := hdrhistogram.New(100, 10000000, 3)
+	for i := int64(100); i <= 100000; i += 100 {
+		if err := hc.RecordValue(i); err != nil {
+			t.Fatal(err)
+		}
+	}
+	want := hc.ValueAtPercentile(0)
+	if got := hc.ValueAtPercentile(-1); got != want {
+		t.Fatalf("ValueAtPercentile(-1) = %d, want 0th-percentile %d (highestEquivalentValue(0) leak?)", got, want)
+	}
+	if got := hc.ValueAtPercentiles([]float64{-5})[-5]; got != want {
+		t.Fatalf("ValueAtPercentiles([-5])[-5] = %d, want 0th-percentile %d", got, want)
+	}
+}

--- a/hdr_test.go
+++ b/hdr_test.go
@@ -519,26 +519,3 @@ func TestValueAtPercentile_EmptyHistogramReturnsZero(t *testing.T) {
 		}
 	}
 }
-
-// Regression: the 0th percentile must equal the recorded minimum, and low
-// percentiles of a small histogram must not read below Min (Java's
-// max(countAtPercentile,1) rule). A fuzz invariant surfaced this.
-func TestValueAtPercentile_LowPercentilesReachMin(t *testing.T) {
-	h := hdrhistogram.New(1, 1000000, 3)
-	if err := h.RecordValue(42); err != nil { // single sample; Min == Max == 42
-		t.Fatal(err)
-	}
-	min := h.Min()
-	if p0 := h.ValueAtPercentile(0); p0 != min {
-		t.Errorf("ValueAtPercentile(0) = %d, want Min %d", p0, min)
-	}
-	for _, p := range []float64{0, 1, 5, 25, 50, 90, 99, 100} {
-		v := h.ValueAtPercentile(p)
-		if v < h.Min() || v > h.Max() {
-			t.Errorf("ValueAtPercentile(%v) = %d outside [Min %d, Max %d]", p, v, h.Min(), h.Max())
-		}
-		if m := h.ValueAtPercentiles([]float64{p})[p]; m < h.Min() || m > h.Max() {
-			t.Errorf("ValueAtPercentiles(%v) = %d outside [Min %d, Max %d]", p, m, h.Min(), h.Max())
-		}
-	}
-}


### PR DESCRIPTION
## Summary

Three edge-case contract fixes to the percentile APIs, making the singular / map / slice variants
consistent. Each ships a regression test that fails on the current code.

- **Empty histogram (fixes #60).** `ValueAtPercentile` returned `highestEquivalentValue(0)` (e.g. `63`
  for `New(100, …)`) for any percentile > 0 even when `TotalCount() == 0`. Return 0, matching the map/
  slice variants and the documented contract.
- **Negative percentile clamp.** `ValueAtPercentile` clamped only `> 100`; a negative percentile leaked
  `highestEquivalentValue(0)`. Clamp `< 0` to `0`.
- **Map phantom key.** `ValueAtPercentiles([]float64{150})` returned a phantom `{100: 0, 150: <value>}`
  (the seed used the clamped `100` while the scan writes the caller's original `150`). Seed by the
  original percentile; clamp only for the target math; lowest-equivalent branch for percentile `<= 0`.

## Scope notes
- `ValueAtPercentilesSlice`'s matching negative clamp lives in **#64**; this PR doesn't touch `Slice`.
- Java's `max(countAtPercentile, 1)` rule (0th percentile == recorded min; keeps low percentiles ≥ Min)
  is **intentionally out of scope** — it must be applied to all three APIs together, which requires
  coordinating with #64's `Slice` changes, so it belongs in a follow-up. (A fuzz invariant added in #65
  demonstrates the current gap.)

## Validation
`go test ./...`, `go vet`, `gofmt` clean. Existing negative/`>100`/value assertions in
`TestHistogram_ValueAtPercentiles` still pass. New regression tests confirmed to fail on the pre-fix code.