### PR TITLE
percentile: reach the first recorded entry (0th percentile == min) across all APIs

### DIFF
--- a/hdr.go
+++ b/hdr.go
@@ -368,6 +368,13 @@ func (h *Histogram) ValueAtPercentile(percentile float64) int64 {
 	}
 
 	countAtPercentile := int64(((percentile / 100) * float64(h.totalCount)) + 0.5)
+	// Reach at least the first recorded entry so low percentiles of a small
+	// histogram don't round the target to 0 and read an empty leading bucket below
+	// Min (and the 0th percentile is the recorded minimum). Matches the reference
+	// max(countAtPercentile, 1).
+	if countAtPercentile < 1 {
+		countAtPercentile = 1
+	}
 	valueFromIdx := h.getValueFromIdxUpToCount(countAtPercentile)
 	if percentile == 0.0 {
 		return h.lowestEquivalentValue(valueFromIdx)
@@ -461,6 +468,9 @@ func (h *Histogram) ValueAtPercentiles(percentiles []float64) (values map[float6
 		}
 		values[percentile] = 0
 		countAtPercentiles[i] = int64(((clamped / 100) * float64(h.totalCount)) + 0.5)
+		if countAtPercentiles[i] < 1 {
+			countAtPercentiles[i] = 1 // reach at least the first recorded entry
+		}
 	}
 
 	// No recorded values: every target count is 0; return the map of 0's (matches the
@@ -520,6 +530,9 @@ func (h *Histogram) ValueAtPercentilesSlice(percentiles []float64) []int64 {
 			percentile = 0
 		}
 		countAtPercentiles[i] = int64(((percentile / 100) * float64(h.totalCount)) + 0.5)
+		if countAtPercentiles[i] < 1 {
+			countAtPercentiles[i] = 1 // reach at least the first recorded entry
+		}
 	}
 	if h.totalCount == 0 {
 		return result // all zeros

--- a/hdr.go
+++ b/hdr.go
@@ -371,7 +371,9 @@ func (h *Histogram) ValueAtPercentile(percentile float64) int64 {
 	// Reach at least the first recorded entry so low percentiles of a small
 	// histogram don't round the target to 0 and read an empty leading bucket below
 	// Min (and the 0th percentile is the recorded minimum). Matches the reference
-	// max(countAtPercentile, 1).
+	// max(countAtPercentile, 1). An empty histogram is already handled above; on the
+	// off chance totalCount is 0 here, getValueFromIdxUpToCount(1) finds no crossing
+	// and returns 0, so this floor never changes the empty result.
 	if countAtPercentile < 1 {
 		countAtPercentile = 1
 	}

--- a/hdr_test.go
+++ b/hdr_test.go
@@ -664,3 +664,29 @@ func TestPercentiles_ReachMinAcrossAPIs(t *testing.T) {
 		}
 	}
 }
+
+// Regression: a negative percentile must clamp to the 0th percentile identically
+// across all three APIs. In particular ValueAtPercentilesSlice must not leak the
+// first bucket's highest-equivalent (e.g. 127 for New(100,...)) while the singular
+// and map APIs return its lowest-equivalent (64). Guards the exact inconsistency
+// raised in review of the max(count,1) floor.
+func TestPercentiles_NegativeClampAcrossAPIs(t *testing.T) {
+	for _, cfg := range []struct{ lo, hi int64 }{{1, 1000000}, {100, 10000000}} {
+		h := hdrhistogram.New(cfg.lo, cfg.hi, 3)
+		for i := int64(0); i < 1000; i++ {
+			if err := h.RecordValue(cfg.lo + i); err != nil {
+				t.Fatal(err)
+			}
+		}
+		want := h.ValueAtPercentile(0) // the 0th-percentile / lowest-equivalent minimum
+		for _, p := range []float64{-1, -0.0001, -100} {
+			single := h.ValueAtPercentile(p)
+			mapv := h.ValueAtPercentiles([]float64{p})[p]
+			slicev := h.ValueAtPercentilesSlice([]float64{p})[0]
+			if single != want || mapv != want || slicev != want {
+				t.Errorf("New(%d,%d): negative percentile %v inconsistent: single=%d map=%d slice=%d, want %d",
+					cfg.lo, cfg.hi, p, single, mapv, slicev, want)
+			}
+		}
+	}
+}

--- a/hdr_test.go
+++ b/hdr_test.go
@@ -637,3 +637,30 @@ func TestResetClearsMetadata(t *testing.T) {
 		t.Errorf("Reset did not clear totalCount: %d", h.TotalCount())
 	}
 }
+
+// Regression: low percentiles must never read below Min(), and the 0th percentile
+// must equal the recorded minimum, across all three percentile APIs (reference
+// max(countAtPercentile,1) rule). Surfaced by a [Min,Max] fuzz invariant.
+func TestPercentiles_ReachMinAcrossAPIs(t *testing.T) {
+	// Small histograms with unitMagnitude 0 and > 0.
+	for _, cfg := range []struct{ lo, hi int64 }{{1, 1000000}, {100, 10000000}} {
+		h := hdrhistogram.New(cfg.lo, cfg.hi, 3)
+		if err := h.RecordValue(cfg.lo + 41); err != nil { // single sample
+			t.Fatal(err)
+		}
+		min, max := h.Min(), h.Max()
+		if p0 := h.ValueAtPercentile(0); p0 != min {
+			t.Errorf("New(%d,%d): ValueAtPercentile(0)=%d, want Min %d", cfg.lo, cfg.hi, p0, min)
+		}
+		pcts := []float64{0, 1, 5, 25, 50, 90, 99, 100}
+		m := h.ValueAtPercentiles(append([]float64(nil), pcts...))
+		sl := h.ValueAtPercentilesSlice(append([]float64(nil), pcts...))
+		for i, p := range pcts {
+			for _, v := range []int64{h.ValueAtPercentile(p), m[p], sl[i]} {
+				if v < min || v > max {
+					t.Errorf("New(%d,%d): percentile %v -> %d outside [Min %d, Max %d]", cfg.lo, cfg.hi, p, v, min, max)
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Applies the reference implementations' `max(countAtPercentile, 1)` rule to **all three** percentile
APIs — `ValueAtPercentile`, `ValueAtPercentiles`, and `ValueAtPercentilesSlice`.

Without it, low percentiles of a **small** histogram round the target count down to 0 and read an empty
leading bucket, returning a value **below `Min()`**; the 0th percentile returned 0 instead of the
recorded minimum. Applying the rule uniformly keeps the three APIs consistent (the slice-vs-singular
consistency test stays green — applying it to only some of them would diverge them).

This was **surfaced by a fuzz invariant** added in #65 ("every percentile lies within `[Min, Max]`").

## Stacking
Stacked on **#67** (percentile edge contracts: empty-histogram guard, negative clamp, map phantom key).
The first commits here are #67; this PR's contribution is the final commit. It also lightly overlaps
#64's `ValueAtPercentilesSlice` change — both touch the Slice target loop in adjacent regions.

## Validation
`go test ./...` (full, unfiltered), `go vet`, `gofmt` clean. New `TestPercentiles_ReachMinAcrossAPIs`
asserts `p0 == Min` and every low percentile `>= Min` for all three APIs (`unitMagnitude` 0 and > 0);
the existing `TestValueAtPercentilesSlice` cross-API consistency test still passes.
