### PR TITLE
Reset: clear tag and start/end time, not just counts

### DIFF
--- a/hdr.go
+++ b/hdr.go
@@ -260,6 +260,12 @@ func (h *Histogram) Reset() {
 	for i := range h.counts {
 		h.counts[i] = 0
 	}
+	// Also clear the metadata New() initializes, so a reused histogram doesn't carry
+	// a stale tag / start / end time into the next interval (the doc promises the
+	// "original state").
+	h.tag = ""
+	h.startTimeMs = 0
+	h.endTimeMs = 0
 }
 
 // RecordValue records the given value, returning an error if the value is out

--- a/hdr_test.go
+++ b/hdr_test.go
@@ -461,3 +461,28 @@ func TestValueAtPercentilesSlice(t *testing.T) {
 		assert.Equal(t, int64(0), v)
 	}
 }
+
+// Reset must restore the histogram to its original state, including the metadata
+// (tag, start/end time), not just the recorded counts.
+func TestResetClearsMetadata(t *testing.T) {
+	h := hdrhistogram.New(1, 1000000, 3)
+	h.SetTag("svcA")
+	h.SetStartTimeMs(111)
+	h.SetEndTimeMs(222)
+	if err := h.RecordValue(500); err != nil {
+		t.Fatal(err)
+	}
+	h.Reset()
+	if h.Tag() != "" {
+		t.Errorf("Reset did not clear tag: %q", h.Tag())
+	}
+	if h.StartTimeMs() != 0 {
+		t.Errorf("Reset did not clear startTimeMs: %d", h.StartTimeMs())
+	}
+	if h.EndTimeMs() != 0 {
+		t.Errorf("Reset did not clear endTimeMs: %d", h.EndTimeMs())
+	}
+	if h.TotalCount() != 0 {
+		t.Errorf("Reset did not clear totalCount: %d", h.TotalCount())
+	}
+}


### PR DESCRIPTION
`Reset` is documented to restore the histogram to its original state, but it only zeroed `totalCount` and `counts[]`, leaving a stale `tag`/`startTimeMs`/`endTimeMs` from a previous interval — so a reused histogram (common in interval logging) carries the old metadata forward. Clear them too, matching `New()`'s initialization. Regression test included; `go test ./...`/`vet`/`gofmt` clean.