### PR TITLE
bench: remove dead fill loop that panics for b.N > 1e6

### DIFF
--- a/hdr_benchmark_test.go
+++ b/hdr_benchmark_test.go
@@ -58,11 +58,7 @@ func BenchmarkHistogramValueAtPercentileGivenPercentileSlice(b *testing.B) {
 	var lowestDiscernibleValue int64 = 1
 	var sigfigs = 3
 	var totalDatapoints = 1000000
-	h, data := populateHistogramLogNormalDist(b, lowestDiscernibleValue, highestTrackableValue, sigfigs, totalDatapoints)
-	quantiles := make([]float64, b.N)
-	for i := range quantiles {
-		data[i] = rand.Float64() * 100.0
-	}
+	h, _ := populateHistogramLogNormalDist(b, lowestDiscernibleValue, highestTrackableValue, sigfigs, totalDatapoints)
 	percentilesOfInterest := []float64{50.0, 95.0, 99.0, 99.9}
 	b.ResetTimer()
 	b.ReportAllocs()
@@ -80,11 +76,7 @@ func BenchmarkHistogramValueAtPercentilesGivenPercentileSlice(b *testing.B) {
 	var lowestDiscernibleValue int64 = 1
 	var sigfigs = 3
 	var totalDatapoints = 1000000
-	h, data := populateHistogramLogNormalDist(b, lowestDiscernibleValue, highestTrackableValue, sigfigs, totalDatapoints)
-	quantiles := make([]float64, b.N)
-	for i := range quantiles {
-		data[i] = rand.Float64() * 100.0
-	}
+	h, _ := populateHistogramLogNormalDist(b, lowestDiscernibleValue, highestTrackableValue, sigfigs, totalDatapoints)
 	percentilesOfInterest := []float64{50.0, 95.0, 99.0, 99.9}
 	b.ResetTimer()
 	b.ReportAllocs()


### PR DESCRIPTION
Two percentile benchmarks ran `for i := range make([]float64, b.N) { data[i] = rand.Float64()*100 }` — which fills `data` (unused) instead of `quantiles`, and indexes a fixed 1e6-element slice `b.N` times, so `go test -bench . -benchtime=2000000x` panics with index out of range. The loop is dead (the benchmarks query a fixed percentile set), so it's removed along with the unused slices. Verified running at b.N=2e6 without panic; `go vet` clean.