### PR TITLE
fix(log): decode final interval line lacking a trailing newline

### DIFF
--- a/log_reader.go
+++ b/log_reader.go
@@ -97,9 +97,15 @@ func (hlr *HistogramLogReader) decodeNextIntervalHistogram() (histogram *Histogr
 		if err != nil {
 			if err == io.EOF {
 				err = nil
+				// A final line lacking a trailing newline is returned by
+				// ReadString together with io.EOF. Process it before
+				// terminating so the last interval is not silently dropped.
+				if line == "" {
+					break
+				}
+			} else {
 				break
 			}
-			break
 		}
 		if line[0] == '#' {
 			matchRes := hlr.reStartTime.FindStringSubmatch(line)

--- a/log_writer_test.go
+++ b/log_writer_test.go
@@ -84,6 +84,54 @@ func assertGoldenInterval0(t *testing.T, h *Histogram) {
 	assert.Equal(t, goldenIntv0P99, h.ValueAtPercentile(99))
 }
 
+// drainAllIntervals reads every interval histogram from the reader and
+// returns them, failing the test on any decode error.
+func drainAllIntervals(t *testing.T, reader *HistogramLogReader) []*Histogram {
+	t.Helper()
+	var out []*Histogram
+	for {
+		h, err := reader.NextIntervalHistogram()
+		assert.Nil(t, err)
+		if h == nil {
+			break
+		}
+		out = append(out, h)
+	}
+	return out
+}
+
+// TestHistogramLogReader_finalLineNoTrailingNewline verifies that the final
+// interval line is still decoded when the log does not end with a newline.
+// bufio.Reader.ReadString returns the buffered final line together with
+// io.EOF; the reader must process it rather than drop it.
+func TestHistogramLogReader_finalLineNoTrailingNewline(t *testing.T) {
+	var b bytes.Buffer
+	writer := NewHistogramLogWriter(&b)
+	for k := 0; k < 3; k++ {
+		h := New(1, 1000, 3)
+		assert.Nil(t, h.RecordValue(int64(10+k)))
+		h.SetStartTimeMs(int64(1000 * (k + 1)))
+		h.SetEndTimeMs(int64(1000 * (k + 2)))
+		assert.Nil(t, writer.OutputIntervalHistogram(h))
+	}
+
+	raw := b.Bytes()
+	withNewline := drainAllIntervals(t, NewHistogramLogReader(bytes.NewReader(raw)))
+	assert.Equal(t, 3, len(withNewline))
+
+	// Strip the single trailing newline and confirm all three intervals
+	// are still returned (previously the last one was silently dropped).
+	stripped := raw
+	if n := len(stripped); n > 0 && stripped[n-1] == '\n' {
+		stripped = stripped[:n-1]
+	}
+	withoutNewline := drainAllIntervals(t, NewHistogramLogReader(bytes.NewReader(stripped)))
+	assert.Equal(t, 3, len(withoutNewline))
+	assert.Equal(t, withNewline[2].TotalCount(), withoutNewline[2].TotalCount())
+	assert.Equal(t, withNewline[2].Max(), withoutNewline[2].Max())
+	assert.Equal(t, withNewline[2].StartTimeMs(), withoutNewline[2].StartTimeMs())
+}
+
 func TestHistogramLogReader_logV2(t *testing.T) {
 	dat, err := os.ReadFile("./test/jHiccup-2.0.7S.logV2.hlog")
 	assert.Equal(t, nil, err)


### PR DESCRIPTION
## Problem

`bufio.Reader.ReadString('\n')` returns the buffered final line **together with** `io.EOF` when the input does not end in a newline. `HistogramLogReader.decodeNextIntervalHistogram` broke out of its read loop immediately on `io.EOF` without processing `line`, so an interval line without a trailing newline was **silently dropped**.

## Fix

On `io.EOF`, only break when the returned `line` is empty; otherwise fall through and decode the buffered final line. The subsequent read returns `("", io.EOF)` and terminates the loop, so there is no infinite loop.

Payload parsing is byte-identical with or without the trailing newline: the payload capture group `(.*)` uses default semantics, so `.` never crosses a `'\n'`.

## Scope

All bundled `.hlog` fixtures end in a newline, so existing behavior is unchanged. This only affects logs/streams whose final line is unterminated — valid HdrHistogram log input that other implementations emit.

## Test

`TestHistogramLogReader_finalLineNoTrailingNewline` writes 3 intervals, strips the trailing newline, and asserts all 3 are still read and the last interval decodes identically (TotalCount/Max/StartTimeMs) to the newline-terminated read.

`go test ./...`, `go vet ./...`, `gofmt` all clean.

> Note: a malformed final line of the form `Tag=x` (no comma) can reach the pre-existing negative-index slice in the `Tag=` block. That defect is independent of this change (it already triggers for any such line mid-file) and is guarded separately in #65's log-reader hardening.