### PR TITLE
fix: reject a negative count in RecordValues

### DIFF
--- a/hdr.go
+++ b/hdr.go
@@ -294,7 +294,7 @@ func (h *Histogram) RecordCorrectedValue(v, expectedInterval int64) error {
 }
 
 // RecordValues records n occurrences of the given value, returning an error if
-// the value is out of range.
+// the value is out of range or n is negative.
 func (h *Histogram) RecordValues(v, n int64) error {
 	idx := h.countsIndexFor(v)
 	// Single unsigned comparison instead of two signed ones: a negative idx wraps
@@ -306,6 +306,12 @@ func (h *Histogram) RecordValues(v, n int64) error {
 	// h.countsLen guard on all inputs.
 	if uint(idx) >= uint(len(h.counts)) {
 		return fmt.Errorf("value %d is too large to be recorded", v)
+	}
+	// A negative n would silently drive counts[idx] and totalCount negative,
+	// corrupting every subsequent percentile/mean query. Reject it. n == 0 is a
+	// harmless no-op and is left to fall through.
+	if n < 0 {
+		return fmt.Errorf("cannot record a negative count %d", n)
 	}
 	h.setCountAtIndex(idx, n)
 

--- a/hdr_test.go
+++ b/hdr_test.go
@@ -245,6 +245,40 @@ func TestRecordCorrectedValueStall(t *testing.T) {
 	}
 }
 
+func TestRecordValuesRejectsNegativeCount(t *testing.T) {
+	h := hdrhistogram.New(1, 100000, 3)
+	if err := h.RecordValue(50); err != nil {
+		t.Fatal(err)
+	}
+	before := h.TotalCount()
+
+	// A negative count must be rejected, not silently subtracted (which would
+	// drive counts[idx] and TotalCount negative and corrupt every query).
+	if err := h.RecordValues(50, -5); err == nil {
+		t.Fatal("RecordValues with a negative count should return an error")
+	}
+	if got := h.TotalCount(); got != before {
+		t.Errorf("TotalCount changed after a rejected negative record: got %d, want %d", got, before)
+	}
+
+	// A negative count on an otherwise-empty histogram must not go negative.
+	empty := hdrhistogram.New(1, 100000, 3)
+	if err := empty.RecordValues(50, -3); err == nil {
+		t.Fatal("RecordValues with a negative count should return an error")
+	}
+	if got := empty.TotalCount(); got != 0 {
+		t.Errorf("TotalCount went negative: got %d, want 0", got)
+	}
+
+	// n == 0 is a legal no-op.
+	if err := empty.RecordValues(50, 0); err != nil {
+		t.Errorf("RecordValues with count 0 should be a no-op, got error: %v", err)
+	}
+	if got := empty.TotalCount(); got != 0 {
+		t.Errorf("TotalCount after a zero-count record: got %d, want 0", got)
+	}
+}
+
 func TestCumulativeDistribution(t *testing.T) {
 	h := hdrhistogram.New(1, 100000000, 3)
 


### PR DESCRIPTION
## Problem

`RecordValues(v, n int64)` ran `counts[idx] += n; totalCount += n` with no sign check on `n`. A **negative** `n` silently drove `counts[idx]` and `totalCount` negative, corrupting every subsequent percentile / mean / distribution query.

```go
h := New(1, 100000, 3)
h.RecordValue(50)          // TotalCount == 1
h.RecordValues(50, -5)     // no error; TotalCount == -4  ← corrupt
```

## Fix

Reject a negative `n` with an error, consistent with the existing out-of-range guard. `n == 0` remains a legal no-op.

The check is placed **after** the `uint(idx) >= uint(len(h.counts))` memory-safety bound (which lets the compiler elide the bounds check on the `counts[idx]` store — the point of #64) and **before** the store. On the write hot path `RecordValue → RecordValues(v, 1)` the branch is never taken and perfectly predictable:

```
BenchmarkHistogramRecordValue-14   3.29 / 3.21 / 3.32 ns/op   0 allocs   (unchanged vs base)
```

## Scope

This closes the `RecordValues` ingestion path. Note `Import` still `copy`s a caller-supplied `Snapshot.Counts` verbatim, so a hand-crafted snapshot with negative buckets would bypass this guard — a pre-existing, separate concern left for a possible follow-up.

Stricter than the Java/C reference (which don't guard here), but negative occurrence counts are nonsensical and no cross-port behavior depends on the old silent-corruption path.

## Test

`TestRecordValuesRejectsNegativeCount`: negative `n` on a populated histogram → error, `TotalCount` unchanged; negative `n` on an empty histogram → error, `TotalCount` stays 0; `n == 0` → no-op, nil.

`go test ./...`, `go vet ./...`, `gofmt` all clean.